### PR TITLE
catch and log exceptions thrown in waiters added to KafkaFuture

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
@@ -102,7 +102,7 @@ public class DeleteAclsResult {
      */
     public KafkaFuture<Collection<AclBinding>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
-            new KafkaFuture.Function<Void, Collection<AclBinding>>() {
+            new KafkaFuture.FunctionInterface<Void, Collection<AclBinding>>() {
                 @Override
                 public Collection<AclBinding> apply(Void v) {
                     List<AclBinding> acls = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
@@ -53,7 +53,7 @@ public class DescribeConfigsResult {
      */
     public KafkaFuture<Map<ConfigResource, Config>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
-                thenApply(new KafkaFuture.Function<Void, Map<ConfigResource, Config>>() {
+                thenApply(new KafkaFuture.FunctionInterface<Void, Map<ConfigResource, Config>>() {
                     @Override
                     public Map<ConfigResource, Config> apply(Void v) {
                         Map<ConfigResource, Config> configs = new HashMap<>(futures.size());

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeLogDirsResult.java
@@ -51,7 +51,7 @@ public class DescribeLogDirsResult {
      */
     public KafkaFuture<Map<Integer, Map<String, LogDirInfo>>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
-            thenApply(new KafkaFuture.Function<Void, Map<Integer, Map<String, LogDirInfo>>>() {
+            thenApply(new KafkaFuture.FunctionInterface<Void, Map<Integer, Map<String, LogDirInfo>>>() {
                 @Override
                 public Map<Integer, Map<String, LogDirInfo>> apply(Void v) {
                     Map<Integer, Map<String, LogDirInfo>> descriptions = new HashMap<>(futures.size());

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeReplicaLogDirsResult.java
@@ -52,7 +52,7 @@ public class DescribeReplicaLogDirsResult {
      */
     public KafkaFuture<Map<TopicPartitionReplica, ReplicaLogDirInfo>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
-            thenApply(new KafkaFuture.Function<Void, Map<TopicPartitionReplica, ReplicaLogDirInfo>>() {
+            thenApply(new KafkaFuture.FunctionInterface<Void, Map<TopicPartitionReplica, ReplicaLogDirInfo>>() {
                 @Override
                 public Map<TopicPartitionReplica, ReplicaLogDirInfo> apply(Void v) {
                     Map<TopicPartitionReplica, ReplicaLogDirInfo> replicaLogDirInfos = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
@@ -51,7 +51,7 @@ public class DescribeTopicsResult {
      */
     public KafkaFuture<Map<String, TopicDescription>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
-            thenApply(new KafkaFuture.Function<Void, Map<String, TopicDescription>>() {
+            thenApply(new KafkaFuture.FunctionInterface<Void, Map<String, TopicDescription>>() {
                 @Override
                 public Map<String, TopicDescription> apply(Void v) {
                     Map<String, TopicDescription> descriptions = new HashMap<>(futures.size());

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsResult.java
@@ -48,7 +48,7 @@ public class ListTopicsResult {
      * Return a future which yields a collection of TopicListing objects.
      */
     public KafkaFuture<Collection<TopicListing>> listings() {
-        return future.thenApply(new KafkaFuture.Function<Map<String, TopicListing>, Collection<TopicListing>>() {
+        return future.thenApply(new KafkaFuture.FunctionInterface<Map<String, TopicListing>, Collection<TopicListing>>() {
             @Override
             public Collection<TopicListing> apply(Map<String, TopicListing> namesToDescriptions) {
                 return namesToDescriptions.values();
@@ -60,7 +60,7 @@ public class ListTopicsResult {
      * Return a future which yields a collection of topic names.
      */
     public KafkaFuture<Set<String>> names() {
-        return future.thenApply(new KafkaFuture.Function<Map<String, TopicListing>, Set<String>>() {
+        return future.thenApply(new KafkaFuture.FunctionInterface<Map<String, TopicListing>, Set<String>>() {
             @Override
             public Set<String> apply(Map<String, TopicListing> namesToListings) {
                 return namesToListings.keySet();

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -35,18 +35,26 @@ public abstract class KafkaFuture<T> implements Future<T> {
     /**
      * A function which takes objects of type A and returns objects of type B.
      */
-    public static abstract class Function<A, B> {
-        public abstract B apply(A a);
+    public interface FunctionInterface<A, B> {
+        B apply(A a);
     }
+    
+    /**
+     * A function which takes objects of type A and returns objects of type B.
+     *
+     * @deprecated use {@link FunctionInterface} instead
+     */
+    @Deprecated
+    public static abstract class Function<A, B> implements FunctionInterface<A, B> { }
 
     /**
      * A consumer of two different types of object.
      */
-    public static abstract class BiConsumer<A, B> {
-        public abstract void accept(A a, B b);
+    public interface BiConsumer<A, B> {
+        void accept(A a, B b);
     }
 
-    private static class AllOfAdapter<R> extends BiConsumer<R, Throwable> {
+    private static class AllOfAdapter<R> implements BiConsumer<R, Throwable> {
         private int remainingResponses;
         private KafkaFuture<?> future;
 
@@ -102,9 +110,23 @@ public abstract class KafkaFuture<T> implements Future<T> {
      * Returns a new KafkaFuture that, when this future completes normally, is executed with this
      * futures's result as the argument to the supplied function.
      */
+    public abstract <R> KafkaFuture<R> thenApply(FunctionInterface<T, R> function);
+
+    /**
+     * @see KafkaFuture#thenApply(FunctionInterface)
+     *
+     * @deprecated use {@link KafkaFuture#thenApply(FunctionInterface)}
+     */
+    @Deprecated
     public abstract <R> KafkaFuture<R> thenApply(Function<T, R> function);
 
-    protected abstract void addWaiter(BiConsumer<? super T, ? super Throwable> action);
+    /**
+     * When this future is done, the given action is invoked with the result (or null if none)
+     * and the exception (or null if none) of this future as arguments.
+     *
+     * @param action the action to perform
+     */
+    public abstract void addWaiter(BiConsumer<? super T, ? super Throwable> action);
 
     /**
      * If not already completed, sets the value returned by get() and related methods to the given

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -109,6 +109,12 @@ public abstract class KafkaFuture<T> implements Future<T> {
     /**
      * Returns a new KafkaFuture that, when this future completes normally, is executed with this
      * futures's result as the argument to the supplied function.
+     *
+     * The function may be called by the thread that calls {@code thenApply} or it may be called
+     * by the thread that completes this future.
+     *
+     * Exceptions thrown by the function will cause the resulting future to complete exceptionally,
+     * with the exception thrown by the function.
      */
     public abstract <R> KafkaFuture<R> thenApply(FunctionInterface<T, R> function);
 
@@ -123,6 +129,12 @@ public abstract class KafkaFuture<T> implements Future<T> {
     /**
      * When this future is done, the given action is invoked with the result (or null if none)
      * and the exception (or null if none) of this future as arguments.
+     *
+     * The action may be invoked by the thread that calls {@code addWaiter} or it may be invoked
+     * by the thread that completes the future.
+     *
+     * Exceptions thrown by the action will be caught and logged to prevent them from affecting
+     * other actions waiting on this future or the calling thread.
      *
      * @param action the action to perform
      */

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -24,13 +24,15 @@ import org.junit.rules.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A unit test for KafkaFuture.
@@ -122,6 +124,51 @@ public class KafkaFutureTest {
         futureFail.completeExceptionally(new RuntimeException());
         assertTrue(futureFail.isCompletedExceptionally());
         assertTrue(futureAppliedFail.isCompletedExceptionally());
+    }
+
+    @Test
+    public void testAddWaiterWithExceptions() {
+        final CountDownLatch allDone = new CountDownLatch(3);
+
+        KafkaFutureImpl<Integer> future = new KafkaFutureImpl<>();
+        future.addWaiter(new KafkaFuture.BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer integer, Throwable throwable) {
+                allDone.countDown();
+            }
+        });
+        assertFalse(future.isDone());
+        future.addWaiter(new KafkaFuture.BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer integer, Throwable throwable) {
+                allDone.countDown();
+                throw new RuntimeException("test bad waiter");
+            }
+        });
+        assertFalse(future.isDone());
+        future.addWaiter(new KafkaFuture.BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer integer, Throwable throwable) {
+                allDone.countDown();
+            }
+        });
+        assertEquals(3, allDone.getCount());
+        future.complete(21);
+        assertEquals(0, allDone.getCount());
+
+        final AtomicBoolean invokeOnFailure = new AtomicBoolean(false);
+        KafkaFutureImpl<Integer> futureFail = new KafkaFutureImpl<>();
+        futureFail.addWaiter(
+            new KafkaFuture.BiConsumer<Integer, Throwable>() {
+                @Override
+                public void accept(Integer integer, Throwable throwable) {
+                    invokeOnFailure.set(true);
+                }
+            }
+        );
+        futureFail.completeExceptionally(new RuntimeException());
+        assertTrue(futureFail.isCompletedExceptionally());
+        assertTrue(invokeOnFailure.get());
     }
 
     private static class CompleterThread<T> extends Thread {

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockScheduler.java
@@ -87,7 +87,7 @@ public class MockScheduler implements Scheduler, MockTime.MockTimeListener {
                                   final Callable<T> callable, long delayMs) {
         final KafkaFutureImpl<T> future = new KafkaFutureImpl<>();
         KafkaFutureImpl<Long> waiter = new KafkaFutureImpl<>();
-        waiter.thenApply(new KafkaFuture.Function<Long, Void>() {
+        waiter.thenApply(new KafkaFuture.FunctionInterface<Long, Void>() {
             @Override
             public Void apply(final Long now) {
                 executor.submit(new Callable<Void>() {

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/WorkerManager.java
@@ -290,7 +290,7 @@ public final class WorkerManager {
                 return;
             }
             KafkaFutureImpl<String> haltFuture = new KafkaFutureImpl<>();
-            haltFuture.thenApply(new KafkaFuture.Function<String, Void>() {
+            haltFuture.thenApply(new KafkaFuture.FunctionInterface<String, Void>() {
                 @Override
                 public Void apply(String errorString) {
                     if (errorString.isEmpty()) {


### PR DESCRIPTION
Exceptions thrown within actions added with KafkaFuture.addWaiter(...) could prevent other waiting actions from executing, possibly breaking KafkaFuture.allOf(), so it seems advisable
to wrap actions to catch and log exceptions before making this API public.